### PR TITLE
URLをテキストに移動

### DIFF
--- a/components/temp.tsx
+++ b/components/temp.tsx
@@ -161,8 +161,7 @@ const Temp = () => {
       type: 'image/png',
     })
     const shareData = {
-      text: '#テロップつくるくん',
-      url: 'https://telopkun.com',
+      text: '#テロップつくるくん https://image-edit-khaki.vercel.app/',
       files: [imageFile],
     }
 


### PR DESCRIPTION
tweetでの動作確認用
URL欄ではツイート文面に反映されなかった（Twitter以外のリマインダーなど他のShareでは見えていた）ため、テキストに移動